### PR TITLE
ci: set all pull requests to draft on open (VF-2169)

### DIFF
--- a/.github/workflows/make-pr-draft.yaml
+++ b/.github/workflows/make-pr-draft.yaml
@@ -1,0 +1,16 @@
+# Marks all newly opened pull requests as drafts
+name: Draft on Open
+on:
+  pull_request:
+    types: [ opened ]
+
+jobs:
+  mark-as-draft:
+    name: Mark as draft
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark as draft
+        uses: voiceflow/draft-pr@latest
+        with:
+          token: ${{ secrets.GH_SA_TOKEN }}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Part or VF-2169**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Since we cannot currently set pull requests to be drafts automatically, this workflow will mark all newly opened PRs as drafts.

Tests:
- https://github.com/voiceflow/poc-autorebase-gh-action/runs/4120331397?check_suite_focus=true

### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded

