### PR TITLE
ci: mark as ready upon adding label (VF-2455)

### DIFF
--- a/.github/workflows/ready_on_label.yml
+++ b/.github/workflows/ready_on_label.yml
@@ -1,0 +1,16 @@
+# Marks PR Ready on label
+name: Ready on Label
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  mark-as-draft:
+    name: Mark as draft
+    if: github.event.label.name == 'ready for review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark as ready 
+        run: gh pr ready $GITHUB_HEAD_REF --repo $GITHUB_REPOSITORY 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_SA_TOKEN }}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Part or VF-2455**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

This adds a small workflow to set your PR as ready when you add the `ready for review` label.

### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded

