### PR TITLE
chore(deps): update peer dependencies (VF-3118)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fixpack": "^4.0.0",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.3",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.0",
     "prettier-eslint-cli": "^5.0.0"
   },
   "files": [
@@ -38,7 +38,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1 || ^2.0.0"
   },
   "prettier": "@voiceflow/prettier-config",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,10 +4083,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1, prettier@^1.7.0:
+prettier@^1.7.0:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 pretty-format@^23.0.1:
   version "23.6.0"


### PR DESCRIPTION
**Fixes or implements VF-3118**

### Brief description. What is this change?
voiceflow/prettier-config is throwing warnings when installing with voiceflow/eslint-config because the second one as a peer dependency on prettier >=2.0.0 while the first one has one on prettier  ^1.91.1.

With this change voiceflow/prettier-config will now accept both ^1.19.1 or ^2.0.0 which should solve the warning.

### Implementation details. How do you make this change?
Allowing on the package.json both lib versions as peer dependecy
