### PR TITLE
chore(renovate): fix renovate automerge (VF-3507)

### DIFF
--- a/.github/workflows/renovate-delegate.yaml
+++ b/.github/workflows/renovate-delegate.yaml
@@ -3,12 +3,12 @@ name: Renovatebot Bors Merge
 
 on:
   issue_comment:
-    types: [created, edited, deleted]
+    types: [created]
 
 jobs:
   service-account-merge:
     if: ${{ contains( github.event.comment.body, 'service-account merge') && github.event.issue.pull_request && github.actor == 'renovate[bot]' }}
-    name: Service Account Merge 
+    name: Service Account Merge
     runs-on: ubuntu-latest
     steps:
       - name: Merge Comment


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
**Fixes or implements VF-3507**
### Brief description. What is this change?
Use service account to merge automerged renovate PRs.
